### PR TITLE
Use mce_css instead of add_editor-style

### DIFF
--- a/ts-fonts.php
+++ b/ts-fonts.php
@@ -22,11 +22,14 @@ if ( ! function_exists( 'twentysixteen_setup' ) ) {
 }
 add_action ( 'wp_enqueue_scripts', 'tsf_loadcss', 11 );
 
-function tsf_editorcss () {
-if ( ! function_exists( 'twentysixteen_setup' ) ) {
-  return;
-}
+function tsf_editorcss( $mce_css ) {
+  if ( ! function_exists( 'twentysixteen_setup' ) ) {
+    return;
+  }
   $extension = defined ( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? 'css' : 'min.css';
-  add_editor_style ( array ( plugins_url ( 'css/fonts.' . $extension , __FILE__ ) ) );
+	if ( ! empty( $mce_css ) )
+		$mce_css .= ',';
+	$mce_css .= plugins_url ( 'css/fonts.' . $extension , __FILE__ );
+	return $mce_css;
 }
-add_action ( 'admin_init', 'tsf_editorcss', 11 );
+add_filter( 'mce_css', 'tsf_editorcss' );


### PR DESCRIPTION
そのまま使ったら、オリジナルのほうの editor-style が後に読み込まれ、上書きされてしまいました。

直すついでに add_editor_style の Codex を呼んだところ、プラグインから読み込む場合は [mce css](https://codex.wordpress.org/Plugin_API/Filter_Reference/mce_css) を使いましょう、とあったので、こちらに書き換えてみました。

自分のブログではうまく動いています。
<img width="658" alt="_2015_11_18_15_21" src="https://cloud.githubusercontent.com/assets/1886443/11234106/186096c8-8e08-11e5-81da-80f09d4ec4c8.png">
